### PR TITLE
fix typo in template for Text.Json.Serialization.JsonPropertyName (#1…

### DIFF
--- a/src/NJsonSchema.CodeGeneration.CSharp/Templates/Class.liquid
+++ b/src/NJsonSchema.CodeGeneration.CSharp/Templates/Class.liquid
@@ -49,7 +49,7 @@
     /// <summary>{{ property.Description | csharpdocs }}</summary>
 {%   endif -%}
 {% if UseSystemTextJson -%}
-    [System.Text.Json.Serialization.JsonPropertyName("{{ property.Name }}"]
+    [System.Text.Json.Serialization.JsonPropertyName("{{ property.Name }}")]
 {%   if property.IsStringEnumArray -%}
     // TODO(system.text.json): Add string enum item converter
 {%   endif -%}


### PR DESCRIPTION
…321)

Co-authored-by: avoronkov <avoronkov>